### PR TITLE
Fix: Trace example doesn't build

### DIFF
--- a/render/examples/trace.rs
+++ b/render/examples/trace.rs
@@ -1,6 +1,6 @@
-use pdf::file::{FileOptions};
-use pdf_render::tracer::{TraceCache, Tracer};
+use pdf::file::FileOptions;
 use pdf_render::render_page;
+use pdf_render::tracer::{TraceCache, Tracer};
 
 fn main() {
     env_logger::init();
@@ -8,11 +8,13 @@ fn main() {
 
     let file = FileOptions::cached().open(&arg).unwrap();
     let resolver = file.resolver();
-    
+
     let mut cache = TraceCache::new();
+
     for page in file.pages() {
         let p = page.unwrap();
-        let mut backend = Tracer::new(&mut cache);
+        let mut clip_paths = vec![];
+        let mut backend = Tracer::new(&mut cache, &mut clip_paths);
         render_page(&mut backend, &resolver, &p, Default::default()).unwrap();
         let items = backend.finish();
         for i in items {


### PR DESCRIPTION
Trace example appears to have broken due to contract change [here](https://github.com/pdf-rs/pdf_render/commit/9f2b7f5bc325aa79a6f8b9be0938ce530c73b51d#diff-e6805d73b52f8bc08fa268468859946a445e92fa25f709452ff5466c8206bf27R72); I took a guess at how this is intended to work.