### PR TITLE
fix: remove dbg

### DIFF
--- a/render/src/font.rs
+++ b/render/src/font.rs
@@ -67,7 +67,6 @@ impl StandardCache {
         };
         let db_path = dir.join("db");
         let font_db = db_path.is_dir().then(|| FontDb::new(db_path));
-        dbg!(&dump);
 
         StandardCache {
             inner: SyncCache::new(),


### PR DESCRIPTION
Hello, I'm trying to use this lib and it works great but it looks like there's a `dbg!` macro call that's running even in release mode 😅 